### PR TITLE
Fix DAB status printing because of strings in PROGMEM

### DIFF
--- a/examples/DABApp/DABApp.ino
+++ b/examples/DABApp/DABApp.ino
@@ -35,7 +35,7 @@ const char pty_14[] PROGMEM =  "Serious classical";
 const char pty_15[] PROGMEM =  "Other music";
 const char pty_16[] PROGMEM =  "Weather";
 const char pty_17[] PROGMEM =  "Finance";
-const char pty_18[] PROGMEM =  "Children’s programmes";
+const char pty_18[] PROGMEM =  "Childrenâ€™s programmes";
 const char pty_19[] PROGMEM =  "Social Affairs";
 const char pty_20[] PROGMEM =  "Religion";
 const char pty_21[] PROGMEM =  "Phone In";
@@ -505,14 +505,14 @@ void DAB_status(void)
   Dab.status();
   Serial.print(Dab.service[service].Label);
   Serial.print(F("\n"));
-  sprintf(dabstring,"PTY = %s (%d)\n", pty[Dab.pty], Dab.pty);
+  sprintf_P(dabstring,PSTR("PTY = %S (%d)\n"), pgm_read_word(&pty[Dab.pty]), Dab.pty);
   Serial.print(dabstring); 
 
   sprintf(dabstring,"Bit Rate = %d kHz, ", Dab.bitrate);
   Serial.print(dabstring);
   sprintf(dabstring,"Sample Rate = %d Hz, ", Dab.samplerate);
   Serial.print(dabstring); 
-  sprintf(dabstring,"Audio Mode = %s (%d)\n", audiomode[Dab.mode], Dab.mode);
+  sprintf_P(dabstring,PSTR("Audio Mode = %S (%d)\n"), pgm_read_word(&audiomode[Dab.mode]), Dab.mode);
   Serial.print(dabstring); 
   
   sprintf(dabstring,"RSSI = %d, SNR = %d, Quality = %d%, ", Dab.signalstrength, Dab.snr, Dab.quality);


### PR DESCRIPTION
The strings for the DAB status display are stored in PROGMEM. When using regular sprintf(), the string is not retrieved from the PROGMEM area. sprintf_P has a special format specifier, %S, to be able to use strings in PROGMEM directly. Use that specifier to get status display working again.